### PR TITLE
商品詳細ページの商品説明表示

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -35,7 +35,7 @@
     <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>


### PR DESCRIPTION
# What
実装不足の対応

# Why
商品詳細ページの商品説明の部分について、
デフォルトのままカラム名を入れていなかったため

***
すでに商品購入機能までLGTMいただいていますが、
Heroku上で機能一つ一つチェックしている時に上記漏れを発見しました。

レビューよろしくお願いいたします。

+ 実装後の詳細ページ
https://gyazo.com/5e4a49fe723f4902db3a2ee518309865